### PR TITLE
Translate the AUX revision to HEX digit for REST

### DIFF
--- a/pyinventorymgr/inventory_items.py
+++ b/pyinventorymgr/inventory_items.py
@@ -67,6 +67,9 @@ def getVersion():
 			parts = line.rstrip('\n').split('=')
 			if (parts[0] == "VERSION_ID"):
 				version = parts[1]
+				if (len(version.split('.')) == 3):
+					aux = str.upper(hex(int(version.split('.')[2].split('-')[0])>>8)[2:])
+					version = version.replace(version.split('.')[2].split('-')[0]+'-', aux+'-')
 	return version
 
 


### PR DESCRIPTION
Currently the aux number must be decimal number in /etc/os-release so
that BMC can translate it to hexadecimal number for IPMI Get Device ID
command.
So we need this fix for REST.

Signed-off-by: johnhcwang hsienchiang@gmail.com
